### PR TITLE
ExportKeySetting: add Safari clipboard fallback with textarea and dow…

### DIFF
--- a/packages/client/src/components/Modal/ModalSettings/components/ExportKeySetting.tsx
+++ b/packages/client/src/components/Modal/ModalSettings/components/ExportKeySetting.tsx
@@ -1,39 +1,89 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { StyledButton, StyledSettingContainer } from '../styled'
 import { Stack, Typography } from '@mui/material'
 import { SectionTitle } from '@/shared/SectionTitle/SectionTitle'
-import { useCopyToClipboard } from 'usehooks-ts'
-import { useParams } from 'react-router-dom'
 import { useEnqueueSnackbar } from '@/hooks/useEnqueueSnackbar'
+import { useParams } from 'react-router-dom'
 import { client } from '@/modules/client'
 
 export const ExportKeySetting = () => {
   const { npub = '' } = useParams<{ npub: string }>()
-  const [, copyToClipboard] = useCopyToClipboard()
   const notify = useEnqueueSnackbar()
+  const [exportedKey, setExportedKey] = useState('')
 
   const exportKey = async () => {
+    if (!npub) return notify('No key identifier provided!', 'error')
+
     try {
       const key = await client.exportKey(npub)
-      if (!key) notify('Specify Cloud Sync password first!', 'error')
-      else if (await copyToClipboard(key)) notify('Key copied to clipboard!')
-      else notify('Failed to copy to clipboard', 'error')
-    } catch (error) {
-      console.log('error', error)
-      notify(`Failed to copy to clipboard: ${error}`, 'error')
+      if (!key) return notify('Specify Cloud Sync password first!', 'error')
+
+      // Try clipboard first
+      try {
+        await navigator.clipboard.writeText(key)
+        notify('Key copied to clipboard!')
+        return
+      } catch (err) {
+        console.warn('Clipboard failed, falling back', err)
+      }
+
+      // Show key in visible textarea fallback
+      setExportedKey(key)
+      notify('Safari blocked clipboard — please copy manually or use the download below.', 'warning')
+    } catch (err) {
+      console.error('Export failed', err)
+      notify(`Failed to export key: ${err}`, 'error')
     }
   }
+
+  const downloadKey = () => {
+    if (!exportedKey) return
+    const blob = new Blob([exportedKey], { type: 'text/plain;charset=utf-8' })
+    const url = window.URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `exported-key-${npub.slice(0, 8)}.txt`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    window.URL.revokeObjectURL(url)
+  }
+
   return (
     <StyledSettingContainer>
-      <Stack direction={'row'} justifyContent={'space-between'}>
+      <Stack direction="row" justifyContent="space-between">
         <SectionTitle>Export</SectionTitle>
       </Stack>
-      <Typography variant="body2" color={'GrayText'}>
+
+      <Typography variant="body2" color="GrayText" sx={{ mb: 1 }}>
         Export your key encrypted with your password (NIP-49)
       </Typography>
+
       <StyledButton type="button" fullWidth onClick={exportKey}>
         Export key
       </StyledButton>
+
+      {exportedKey && (
+        <div style={{ marginTop: '1rem' }}>
+          <Typography variant="body2" sx={{ mb: 0.5 }}>
+            Safari / Clipboard fallback:
+          </Typography>
+          <textarea
+            readOnly
+            value={exportedKey}
+            style={{
+              width: '100%',
+              height: '100px',
+              fontFamily: 'monospace',
+              fontSize: '0.9rem',
+            }}
+            onFocus={(e) => e.target.select()}
+          />
+          <StyledButton onClick={downloadKey} sx={{ mt: 1 }}>
+            Download Key as .txt
+          </StyledButton>
+        </div>
+      )}
     </StyledSettingContainer>
   )
 }


### PR DESCRIPTION
Refactor export key logic:
•	Removed useCopyToClipboard dependency.
•	Replaced single-step clipboard copy with a robust multi-step approach:
•	First attempts navigator.clipboard.writeText().
•	Falls back to displaying key in a visible textarea if clipboard access is blocked (e.g., Safari).
•	Added a download fallback to save key as a .txt file.
State management:
•	Introduced useState for exportedKey to store fallback key for manual copy/download.
•	User notifications:
Enhanced useEnqueueSnackbar usage:
•	Inform users when clipboard fails.
•	Show warnings for Safari clipboard issues.
•	Show error messages if export fails entirely.
UI updates:
•	Added a textarea for Safari/clipboard fallback.
•	Added a Download Key as .txt button for manual export.
•	Minor styling adjustments for textarea and spacing (marginTop, font styling).
Error handling improvements:
•	Console warnings for clipboard failures.
•	Comprehensive try/catch for both key export and clipboard operations.